### PR TITLE
Fix: Remove unexpected keyword argument 'unit'

### DIFF
--- a/custom_components/dachs_modbus/api.py
+++ b/custom_components/dachs_modbus/api.py
@@ -69,9 +69,7 @@ class DachsModbusApiClient:
             try:
                 data = {}
                 # Read all registers in one go
-                result = self._client.read_input_registers(
-                    address=8000, count=84, unit=1
-                )
+                result = self._client.read_input_registers(address=8000, count=84)
                 if result.isError():
                     raise ConnectionException(f"Failed to read registers: {result}")
 
@@ -122,7 +120,7 @@ class DachsModbusApiClient:
     def _send_pin(self):
         """Send the GLT PIN to the device."""
         try:
-            self._client.write_register(address=8300, value=int(self._glt_pin), unit=1)
+            self._client.write_register(address=8300, value=int(self._glt_pin))
         except ConnectionException as e:
             _LOGGER.error("Failed to send GLT PIN: %s", e)
             raise
@@ -132,14 +130,14 @@ class DachsModbusApiClient:
         with self._lock:
             self._send_pin()
             self._power_setpoint = power
-            self._client.write_register(address=8301, value=power, unit=1)
+            self._client.write_register(address=8301, value=power)
             self._start_heartbeat()
 
     def set_block_chp(self, block: bool):
         """Block or unblock the CHP."""
         with self._lock:
             self._send_pin()
-            self._client.write_register(address=8302, value=1 if block else 0, unit=1)
+            self._client.write_register(address=8302, value=1 if block else 0)
 
     def _start_heartbeat(self):
         """Start the heartbeat timer."""


### PR DESCRIPTION
The 'unit' keyword argument is no longer supported in the ModbusClientMixin.read_input_registers() and ModbusClientMixin.write_register() methods. This commit removes the 'unit' argument from all calls to these methods to prevent the integration from failing to set up.